### PR TITLE
Checked Commnecement Date should be less than or equal to todays date

### DIFF
--- a/municipal-services/tl-services/src/main/java/org/egov/tl/service/TradeLicenseService.java
+++ b/municipal-services/tl-services/src/main/java/org/egov/tl/service/TradeLicenseService.java
@@ -103,6 +103,8 @@ public class TradeLicenseService {
      * @return The list of created traddeLicense
      */
     public List<TradeLicense> create(TradeLicenseRequest tradeLicenseRequest,String businessServicefromPath){
+        //Have implemented a check on CommnecementDate
+        tlValidator.validateCommencementDate(tradeLicenseRequest);
        if(businessServicefromPath==null)
             businessServicefromPath = businessService_TL;
        tlValidator.validateBusinessService(tradeLicenseRequest,businessServicefromPath);

--- a/municipal-services/tl-services/src/main/java/org/egov/tl/validator/TLValidator.java
+++ b/municipal-services/tl-services/src/main/java/org/egov/tl/validator/TLValidator.java
@@ -19,6 +19,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -98,6 +101,18 @@ public class TLValidator {
                 throw new CustomException("BUSINESSSERVICE_NOTMATCHING", " The business service inside license not matching with the one sent in path variable");
             }
         }
+    }
+
+    public void validateCommencementDate(TradeLicenseRequest tradeLicenseRequest){
+        LocalDateTime ldt = Instant.ofEpochMilli(tradeLicenseRequest.getLicenses().get(0).getCommencementDate())
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+        System.out.println(ldt);
+        int diff = ldt.compareTo(LocalDateTime.now());
+        if(diff>0 ) {
+            throw new CustomException("INVALID_DATE_SELECTED", " The Commencement Date selected should be less than or equal to todays date");
+        }
+
+
     }
 
     private void validateTLSpecificNotNullFields(TradeLicenseRequest request) {


### PR DESCRIPTION
Have Implemented the check in service class and it will be triggered before any enrichement or mdms call. And the below error will be thrown if the date is greater than todays date.
{
    "ResponseInfo": null,
    "Errors": [
        {
            "code": "INVALID_DATE_SELECTED",
            "message": " The Commencement Date selected should be less than or equal to todays date",
            "description": null,
            "params": null
        }
    ]
}