### PR TITLE
Update the bill Download size for Group Bill

### DIFF
--- a/frontend/mono-ui/web/rainmaker/dev-packages/egov-abg-dev/src/ui-config/screens/specs/utils/index.js
+++ b/frontend/mono-ui/web/rainmaker/dev-packages/egov-abg-dev/src/ui-config/screens/specs/utils/index.js
@@ -139,7 +139,7 @@ export const downloadMultipleBill = async (
       item.additionalDetails = addDetail;
     });
 
-    var actualBills = [],size = 80;
+    var actualBills = [],size = 8;
     for (let i = 0; bills.length > 0; i++) {
       actualBills.push(bills.splice(0, size));
     }


### PR DESCRIPTION
Update the bill size in the request for this API: /pdf-service/v1/_Create. Which will help to download at least 8 Bills in group bill.